### PR TITLE
Remove category 'SE' from FAccT

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -426,7 +426,7 @@
   date: TBA
   place: Chicago, USA
   rank: unranked
-  tags: [SE, HCI, PRIV]
+  tags: [HCI, PRIV]
 
 - name: CSCW
   description: ACM Conference on Computer-Supported Cooperative Work and Social Computing


### PR DESCRIPTION
I realized that FAccT does not really solicit "pure" software engineering papers; therefore I would propose to remove it from this category.