### PR TITLE
Adds SAC 2025

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -217,6 +217,16 @@
   rank: Journal
   tags: [SE, HCI]
 
+- name: SAC
+  description: ACM/SIGAPP Symposium On Applied Computing
+  year: 2025
+  link: https://www.sigapp.org/sac/sac2025/
+  deadline: "2024-09-20 23:59"
+  date: March 31 – April 4
+  place: Sicily, Italy
+  rank: Multiconference
+  tags: [SE, TEST, SEC, PRIV]
+
 # Testing
 
 - name: ISSTA


### PR DESCRIPTION
We used to submit to SAC when it was still B ranked. Different tracks have different acceptance rates, but some are below 30 %. In my view, it makes sense to consider as a venue again.